### PR TITLE
Pinning Latest Dockerfile Content Digest to Parent Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM hello-world:linux
+FROM hello-world:linux@sha256:b19e76ce1a05c7f7857d8fe57d00f6d6a0a757a3f5d92826595186c13d302284


### PR DESCRIPTION
Updating Parent Docker Image to reference content-digest: `sha256:b19e76ce1a05c7f7857d8fe57d00f6d6a0a757a3f5d92826595186c13d302284`